### PR TITLE
Allow any composer version

### DIFF
--- a/recipes/composer
+++ b/recipes/composer
@@ -9,19 +9,23 @@ set -o pipefail
 # fail harder
 set -eux
 
-echo "-----> Bundling Composer (latest)..."
+DEFAULT_VERSION="1.2.0"
+dep_version=${VERSION:-$DEFAULT_VERSION}
+
+echo "-----> Bundling Composer (${dep_version})..."
 
 buildcurl php | tar xz -C $OUT_PREFIX
 
 export PATH=${OUT_PREFIX}/bin:$PATH
 
-curl -sS https://getcomposer.org/installer | php -- --version=1.0.0-alpha10
-
-php composer.phar --version
-
 rm -rf ${OUT_PREFIX}/*
 mkdir -p ${OUT_PREFIX}/bin
 
-mv composer.phar ${OUT_PREFIX}/bin/composer
+curl -sS https://getcomposer.org/installer | php -- \
+  --version=${dep_version} \
+  --filename=composer \
+  --install-dir=${OUT_PREFIX}/bin
+
+php ${OUT_PREFIX}/bin/composer --version
 
 echo "-----> Done."


### PR DESCRIPTION
changed to use composer installer functions
updated default version to 1.2.0
now allows any version. 

Untested, not sure I would test
