### PR TITLE
Add Oracle Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 /cache
 .env
+.idea/

--- a/USAGE.md
+++ b/USAGE.md
@@ -26,6 +26,8 @@ version is specified in the `recipe`, and `prefix` defaults to `/usr/local`.
 * sles:12
 * sles:11
 * fedora:20
+* oraclelinux:6
+* oraclelinux:7
 
 ## Supported recipes
 

--- a/bin/pull
+++ b/bin/pull
@@ -13,6 +13,8 @@ targets=(
 	debian:8
 	sles:11
 	sles:12
+	oraclelinux:6
+	oraclelinux:7
 )
 
 for target in ${targets[@]}; do

--- a/data/targets
+++ b/data/targets
@@ -8,3 +8,5 @@ el:6
 fedora:20
 sles:12
 sles:11
+oraclelinux:6
+oraclelinux:7

--- a/targets/oraclelinux/6/Dockerfile
+++ b/targets/oraclelinux/6/Dockerfile
@@ -1,0 +1,38 @@
+FROM oraclelinux:6
+
+RUN yum makecache fast && yum -y install \
+	git \
+	wget \
+	curl \
+	tar \
+	openssl-devel \
+	readline-devel \
+	libxml2-devel \
+	libxslt-devel \
+	libtool \
+	libevent-devel \
+	postgresql-devel \
+	mysql-devel \
+	sqlite-devel \
+	gcc \
+	gcc-c++ \
+	kernel-devel \
+	cmake \
+	make \
+	autoconf \
+	subversion \
+	zip \
+	file \
+	patch \
+	bzip2-devel \
+	bzip2 \
+	libicu-devel \
+	libpng-devel \
+	libjpeg-devel \
+	freetype-devel \
+	automake \
+	libtool \
+	curl-devel \
+	&& yum clean all
+
+RUN echo "ol:6" > /etc/version

--- a/targets/oraclelinux/7/Dockerfile
+++ b/targets/oraclelinux/7/Dockerfile
@@ -1,0 +1,37 @@
+FROM oraclelinux:7
+
+RUN yum makecache fast && yum -y install \
+	git \
+	wget \
+	curl \
+	tar \
+	openssl-devel \
+	readline-devel \
+	libxml2-devel \
+	libxslt-devel \
+	libevent-devel \
+	postgresql-devel \
+	mysql-devel \
+	sqlite-devel \
+	gcc \
+	gcc-c++ \
+	kernel-devel \
+	cmake make \
+	autoconf \
+	subversion \
+	zip \
+	file \
+	patch \
+	bzip2-devel \
+	bzip2 \
+	libicu-devel \
+	libtool \
+	libpng-devel \
+	libjpeg-devel \
+	freetype-devel \
+	automake \
+	libtool \
+	curl-devel \
+	&& yum clean all
+
+RUN echo "ol:7" > /etc/version


### PR DESCRIPTION
I would like to contribute Oracle Linux support to pkgr, and in the process of doing so I discovered that buildcurl would also need to support Oracle Linux. This is what I have gotten so far.

Building the docker images seems to work, but I haven't gotten buildcurl to work locally (for any target) so I'm not sure whether these changes are sufficient.

I'm running docker on my Mac, creating the container using:

```
docker run -d --name buildcurl -p 80:80 -v /var/run/docker.sock:/var/run/docker.sock -e AWS_ACCESS_KEY_ID=<key> -e AWS_SECRET_ACCESS_KEY=<key> -e AWS_REGION=us-west-2 -e AWS_BUCKET=<bucket> -e BUILDCURL_URL=http://localhost:80 buildcurl/buildcurl
```

Here's the output in the browser when trying to build ruby 2.3.0 for debian 8. I get the same output for any target.

![screen shot 2017-03-24 at 10 08 00 am](https://cloud.githubusercontent.com/assets/4351/24305401/0bb0fb70-107a-11e7-9304-1edfd4d18800.png)

Here's the log from the container.

![screen shot 2017-03-24 at 10 09 39 am](https://cloud.githubusercontent.com/assets/4351/24305407/1375cfe8-107a-11e7-87f0-1bf47d847124.png)

